### PR TITLE
add anyhow context to errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cargo-fixeq"
 version = "0.3.0"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,6 +91,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum memchr 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
 "checksum proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0319972dcae462681daf4da1adeeaa066e3ebd29c69be96c6abb1259d2ee2bcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 repository = "https://github.com/quark-zju/cargo-fixeq"
 
 [dependencies]
+anyhow = "1.0.26"
 lazy_static = "1.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 regex = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,37 +10,38 @@ use std::{
     process::{self, Command},
     str,
 };
+use anyhow::{Context};
 
-fn main() -> io::Result<()> {
+fn main() -> anyhow::Result<()> {
     let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
     let exitcode = loop {
         eprint!("Running tests...");
         let output = Command::new(&cargo)
             .arg("test")
             .args(env::args_os().skip(1).skip_while(|s| s == "fixeq"))
-            .output()?;
+            .output().context("running tests")?;
 
-        let forward_output = || -> io::Result<()> {
+        let forward_output = || -> anyhow::Result<()> {
             eprintln!("Last 'cargo test' output:");
-            io::stderr().flush()?;
-            io::stdout().write_all(&output.stdout)?;
-            io::stderr().write_all(&output.stderr)?;
+            io::stderr().flush().context("flushing stderr")?;
+            io::stdout().write_all(&output.stdout).context("forwarding test stdout")?;
+            io::stderr().write_all(&output.stderr).context("forwarding test stderr")?;
             Ok(())
         };
 
         if output.status.success() {
             eprintln!(" succeeded.");
-            forward_output()?;
+            forward_output().context("reporting success")?;
             break 0;
         }
 
         let out = str::from_utf8(&output.stdout).unwrap_or("");
         let failures = parse_out::find_assert_eq_failures(out);
-        let count = fix::fix(failures)?;
+        let count = fix::fix(failures).context("fixing failures")?;
 
         if count == 0 {
             eprintln!(" failed.");
-            forward_output()?;
+            forward_output().context("reporting failure")?;
             break output.status.code().unwrap_or(0);
         } else {
             eprintln!(" fixed {} assert_eq!s.", count);


### PR DESCRIPTION
Hi.

I should start by saying that I think your tool is an excellent idea, and the implementation seems very clean and easy to understand. I will probably try to use it as a base for implementing https://github.com/alsuren/cargo-ngrok/issues/1 (would you prefer for me to copy-paste the code into my own project, or try to split the re-usable bits out into a library?)

While I was evaluating it, I tried to use your tool from a directory that wasn't the root of the repo, and I found it quite difficult to debug.

I got this error:
```
~/src/actix/examples/template_yarte$ cargo fixeq
Running tests...Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
```

After adding .context() to a bunch of places, I managed to make it give me this error, which is a bit more informative:
```
~/src/actix/examples/template_yarte$ ~/src/cargo-fixeq/target/debug/cargo-fixeq
Running tests...Error: fixing failures

Caused by:
    0: reading "template_yarte/src/main.rs"
    1: No such file or directory (os error 2)
```

Does this sound like a good-enough approach to error handling? (It was pretty low-effort: I just searched for `?` and added `.context("xyz")` everywhere).

Do you want me to change any of the context strings? I've currently gone with a scheme where the messages are all like "doing xyz", but I could change the messages to be more like "could not do xyz" if you would prefer.